### PR TITLE
Fix TableLocation

### DIFF
--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/DriverManager.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/DriverManager.java
@@ -93,7 +93,7 @@ public class DriverManager extends AbstractFunction implements ScalarFunction, D
                 try (Statement st = connection.createStatement()) {
                     String tableName_ = TableLocation.parse(tableName, dbType).toString();
                     st.execute(String.format("CREATE TABLE %s COMMENT %s ENGINE %s WITH %s",
-                            TableLocation.parse(tableName, dbType).toString(),StringUtils.quoteStringSQL(fileName),
+                            tableName_,StringUtils.quoteStringSQL(fileName),
                             StringUtils.quoteJavaString(driverDef.getClassName()),StringUtils.quoteJavaString(fileName)));
                     return new String[]{tableName_};
                 }

--- a/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/io/dbf/DBFDriverFunction.java
@@ -121,7 +121,7 @@ public class DBFDriverFunction implements DriverFunction {
 
         } else {
                 final DBTypes dbType = DBUtils.getDBType(connection);
-                String outputTable = TableLocation.parse(tableReference, dbType).toString();
+                String outputTable = TableLocation.parse(tableReference, dbType).toString(dbType);
                 int recordCount = JDBCUtilities.getRowCount(connection, outputTable);
 
                 // Read table content
@@ -222,7 +222,7 @@ public class DBFDriverFunction implements DriverFunction {
         if (FileUtilities.isFileImportable(fileName, "dbf")) {
             final DBTypes dbType = DBUtils.getDBType(connection);
             TableLocation requestedTable = TableLocation.parse(tableReference, dbType);
-            String outputTable = requestedTable.toString();
+            String outputTable = requestedTable.toString(dbType);
 
             if (deleteTables) {
                 Statement stmt = connection.createStatement();

--- a/h2gis-functions/src/main/java/org/h2gis/functions/spatial/crs/UpdateGeometrySRID.java
+++ b/h2gis-functions/src/main/java/org/h2gis/functions/spatial/crs/UpdateGeometrySRID.java
@@ -25,6 +25,7 @@ import org.h2gis.api.AbstractFunction;
 import org.h2gis.api.ScalarFunction;
 import org.h2gis.utilities.GeometryTableUtilities;
 import org.h2gis.utilities.TableLocation;
+import org.h2gis.utilities.dbtypes.DBTypes;
 
 /**
  * Function to update the SRID of a geometry column
@@ -84,7 +85,7 @@ public class UpdateGeometrySRID  extends AbstractFunction implements ScalarFunct
      * @throws SQLException 
      */
     public static boolean changeSRID(Connection connection, String catalog_name, String schema_name, String table_name, String column_name, int srid) throws SQLException {
-        TableLocation tableLocation = new TableLocation(catalog_name, schema_name, table_name);
+        TableLocation tableLocation = new TableLocation(catalog_name, schema_name, table_name, DBTypes.H2GIS);
         return GeometryTableUtilities.alterSRID(connection, tableLocation, column_name, srid);
     }
 

--- a/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPEngineTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/io/shp/SHPEngineTest.java
@@ -252,7 +252,7 @@ public class SHPEngineTest {
         Statement st = connection.createStatement();
         st.execute("drop table if exists shptable");
         st.execute("CALL FILE_TABLE('"+SHPEngineTest.class.getResource("waternetwork.shp").getPath()+"', 'SHPTABLE');");
-        assertEquals(GeometryTypeCodes.MULTILINESTRING, GeometryTableUtilities.getMetaData(connection, TableLocation.parse("SHPTABLE"), "THE_GEOM").geometryTypeCode);
+        assertEquals(GeometryTypeCodes.MULTILINESTRING, GeometryTableUtilities.getMetaData(connection, TableLocation.parse("SHPTABLE", DBTypes.H2GIS), "THE_GEOM").geometryTypeCode);
         st.execute("drop table shptable");
     }
 
@@ -292,11 +292,11 @@ public class SHPEngineTest {
             rs.close();
         }
         // Check if the index exists
-        assertTrue(hasIndex(connection, TableLocation.parse("SHPTABLE"), "the_geom"));
+        assertTrue(hasIndex(connection, TableLocation.parse("SHPTABLE",DBTypes.H2GIS), "the_geom"));
         st.execute("DROP TABLE IF EXISTS shptable");
 
         // Check if the index exists
-        assertFalse(hasIndex(connection, TableLocation.parse("SHPTABLE"), "the_geom"));
+        assertFalse(hasIndex(connection, TableLocation.parse("SHPTABLE",DBTypes.H2GIS), "the_geom"));
 
 
         //Alphanumeric index
@@ -329,11 +329,11 @@ public class SHPEngineTest {
             rs.close();
         }
         // Check if the index is here
-        assertTrue(hasIndex(connection, TableLocation.parse("SHPTABLE"), "GID"));
+        assertTrue(hasIndex(connection, TableLocation.parse("SHPTABLE",DBTypes.H2GIS), "GID"));
 
         st.execute("DROP TABLE IF EXISTS shptable");
         // Check if the index has been removed
-        assertFalse(hasIndex(connection, TableLocation.parse("SHPTABLE"), "GID"));
+        assertFalse(hasIndex(connection, TableLocation.parse("SHPTABLE",DBTypes.H2GIS), "GID"));
 
     }
 

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/SpatialFunctionTest.java
@@ -28,6 +28,7 @@ import org.h2.value.ValueGeometry;
 import org.h2gis.functions.factory.H2GISDBFactory;
 import org.h2gis.functions.spatial.affine_transformations.ST_Translate;
 import org.h2gis.utilities.TableLocation;
+import org.h2gis.utilities.dbtypes.DBTypes;
 import org.junit.jupiter.api.*;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.io.WKTReader;
@@ -290,7 +291,7 @@ public class SpatialFunctionTest {
                 + "insert into ptClouds(the_geom) VALUES (ST_MPointFromText('MULTIPOINT(5 5, 1 2, 3 4, 99 3)',2154)),"
                 + "(ST_MPointFromText('MULTIPOINT(-5 12, 11 22, 34 41, 65 124)',2154)),"
                 + "(ST_MPointFromText('MULTIPOINT(1 12, 5 -21, 9 41, 32 124)',2154));");
-        Envelope result = GeometryTableUtilities.getEnvelope(connection, TableLocation.parse("PTCLOUDS"), "THE_GEOM").getEnvelopeInternal();
+        Envelope result = GeometryTableUtilities.getEnvelope(connection, TableLocation.parse("PTCLOUDS", DBTypes.H2GIS), "THE_GEOM").getEnvelopeInternal();
         Envelope expected = new Envelope(-5, 99, -21, 124);
         assertEquals(expected.getMinX(), result.getMinX(), 1e-12);
         assertEquals(expected.getMaxX(), result.getMaxX(), 1e-12);

--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/metadata/GeometryTableUtilsTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/metadata/GeometryTableUtilsTest.java
@@ -183,8 +183,9 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testGeometryMetadataUtils() throws Exception {
+        TableLocation location=TableLocation.parse("GEO_POINT",DBTypes.H2);
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY)");
-        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY", geomMetadata.geometryType);
         assertEquals("GEOMETRY", geomMetadata.sfs_geometryType);
         assertEquals(2, geomMetadata.dimension);
@@ -192,7 +193,7 @@ public class GeometryTableUtilsTest {
         assertFalse(geomMetadata.hasZ);
         assertFalse(geomMetadata.hasM);
         st.execute("ALTER TABLE GEO_POINT ALTER COLUMN THE_GEOM type geometry(POINT Z, 4326)");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("POINTZ", geomMetadata.geometryType);
         assertEquals("POINT", geomMetadata.sfs_geometryType);
         assertEquals(3, geomMetadata.dimension);
@@ -200,7 +201,7 @@ public class GeometryTableUtilsTest {
         assertTrue(geomMetadata.hasZ);
         assertFalse(geomMetadata.hasM);
         st.execute("ALTER TABLE GEO_POINT ALTER COLUMN THE_GEOM type geometry(POINTZM)");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("POINTZM", geomMetadata.geometryType);
         assertEquals("POINT", geomMetadata.sfs_geometryType);
         assertEquals(4, geomMetadata.dimension);
@@ -212,7 +213,7 @@ public class GeometryTableUtilsTest {
     @Test
     public void testGeometryMetadataUtils2() throws Exception {
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY, geom GEOMETRY(POINT Z,4326))");
-        LinkedHashMap<String, GeometryMetaData> geomMetadatas = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"));
+        LinkedHashMap<String, GeometryMetaData> geomMetadatas = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT", DBTypes.H2));
         Set<Map.Entry<String, GeometryMetaData>> elements = geomMetadatas.entrySet();
         Iterator<Map.Entry<String, GeometryMetaData>> iterator = elements.iterator();
         Map.Entry<String, GeometryMetaData> geomMetWithField = iterator.next();
@@ -234,7 +235,7 @@ public class GeometryTableUtilsTest {
         assertTrue(geomMetadata.hasZ);
         assertFalse(geomMetadata.hasM);
         st.execute("ALTER TABLE GEO_POINT ALTER COLUMN THE_GEOM type geometry(POINTZM)");
-        geomMetadatas = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"));
+        geomMetadatas = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT", DBTypes.H2));
         elements = geomMetadatas.entrySet();
         geomMetWithField = elements.iterator().next();
         assertEquals("THE_GEOM", geomMetWithField.getKey());
@@ -279,7 +280,7 @@ public class GeometryTableUtilsTest {
         st.execute("CREATE TABLE POINT3D (gid int , the_geom GEOMETRY)");
         ResultSet rs = connection.createStatement().executeQuery("SELECT * FROM POINT3D");
         assertTrue(GeometryTableUtilities.hasGeometryColumn(rs));
-        assertTrue(GeometryTableUtilities.hasGeometryColumn(connection, TableLocation.parse("POINT3D")));
+        assertTrue(GeometryTableUtilities.hasGeometryColumn(connection, TableLocation.parse("POINT3D",DBTypes.H2GIS)));
         st.execute("DROP TABLE IF EXISTS POINT3D");
         st.execute("CREATE TABLE POINT3D (gid int)");
         rs = connection.createStatement().executeQuery("SELECT * FROM POINT3D");
@@ -287,7 +288,7 @@ public class GeometryTableUtilsTest {
         st.execute("DROP SCHEMA IF EXISTS ORBISGIS CASCADE");
         st.execute("CREATE SCHEMA ORBISGIS;");
         st.execute("CREATE TABLE ORBISGIS.POINT3D (gid int , the_geom GEOMETRY)");
-        assertTrue(GeometryTableUtilities.hasGeometryColumn(connection, TableLocation.parse("ORBISGIS.POINT3D")));
+        assertTrue(GeometryTableUtilities.hasGeometryColumn(connection, TableLocation.parse("ORBISGIS.POINT3D",DBTypes.H2GIS)));
     }
 
     @Test
@@ -298,7 +299,7 @@ public class GeometryTableUtilsTest {
         stat.execute("CREATE TABLE POINT3D (gid int , the_geom GEOMETRY)");
         ResultSet rs = conPost.createStatement().executeQuery("SELECT * FROM POINT3D");
         assertTrue(GeometryTableUtilities.hasGeometryColumn(rs));
-        assertTrue(GeometryTableUtilities.hasGeometryColumn(conPost, TableLocation.parse("point3d")));
+        assertTrue(GeometryTableUtilities.hasGeometryColumn(conPost, TableLocation.parse("point3d",DBTypes.POSTGIS)));
         stat.execute("DROP TABLE IF EXISTS POINT3D");
         stat.execute("CREATE TABLE POINT3D (gid int)");
         rs = conPost.createStatement().executeQuery("SELECT * FROM POINT3D");
@@ -306,7 +307,7 @@ public class GeometryTableUtilsTest {
         stat.execute("DROP SCHEMA IF EXISTS ORBISGIS CASCADE");
         stat.execute("CREATE SCHEMA ORBISGIS;");
         stat.execute("CREATE TABLE ORBISGIS.POINT3D (gid int , the_geom GEOMETRY)");
-        assertTrue(GeometryTableUtilities.hasGeometryColumn(conPost, TableLocation.parse("orbisgis.point3d")));
+        assertTrue(GeometryTableUtilities.hasGeometryColumn(conPost, TableLocation.parse("orbisgis.point3d",DBTypes.POSTGIS)));
         stat.execute("DROP SCHEMA IF EXISTS ORBISGIS CASCADE");        
     }
 
@@ -349,7 +350,7 @@ public class GeometryTableUtilsTest {
         geomColumns.add("MULTILINESTR");
         geomColumns.add("MULTIPLGN");
         geomColumns.add("GEOMCOLLECTION");
-        LinkedHashMap<String, Integer> geomFieldNameIndex = GeometryTableUtilities.getGeometryColumnNamesAndIndexes(connection, TableLocation.parse("GEOMTABLE"));
+        LinkedHashMap<String, Integer> geomFieldNameIndex = GeometryTableUtilities.getGeometryColumnNamesAndIndexes(connection, TableLocation.parse("GEOMTABLE", DBTypes.H2));
         assertEquals(8, geomFieldNameIndex.size());
         assertNotNull(geomFieldNameIndex.keySet().stream()
                 .filter(columName -> geomColumns.contains(columName))
@@ -368,7 +369,7 @@ public class GeometryTableUtilsTest {
         geomColumns.add("MULTILINESTR");
         geomColumns.add("MULTIPLGN");
         geomColumns.add("GEOMCOLLECTION");
-        List<String> geomFieldNameIndex = GeometryTableUtilities.getGeometryColumnNames(connection, TableLocation.parse("GEOMTABLE"));
+        List<String> geomFieldNameIndex = GeometryTableUtilities.getGeometryColumnNames(connection, TableLocation.parse("GEOMTABLE", DBTypes.H2));
         assertEquals(8, geomFieldNameIndex.size());
         assertNotNull(geomFieldNameIndex.stream()
                 .filter(columName -> geomColumns.contains(columName))
@@ -507,7 +508,7 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testTableEnvelope() throws SQLException {
-        TableLocation tableLocation = TableLocation.parse("GEOMTABLE");
+        TableLocation tableLocation = TableLocation.parse("GEOMTABLE", DBTypes.H2GIS);
         assertThrows(SQLException.class, ()
                 -> GeometryTableUtilities.getEnvelope(connection, tableLocation, ""));
         assertEquals(new Envelope(1.0, 2.0, 1.0, 2.0),
@@ -530,14 +531,14 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testBadTableEnvelope() throws SQLException {
-        TableLocation tableLocation = TableLocation.parse("NOGEOM");
+        TableLocation tableLocation = TableLocation.parse("NOGEOM", DBTypes.H2GIS);
         assertThrows(SQLException.class, ()
                 -> GeometryTableUtilities.getEnvelope(connection, tableLocation, ""));
     }
 
     @Test
     public void testEstimatedExtentWithoutIndex() throws SQLException {
-        TableLocation tableLocation = TableLocation.parse("GEOMTABLE");
+        TableLocation tableLocation = TableLocation.parse("GEOMTABLE",DBTypes.H2GIS);
         assertEquals(new Envelope(1.0, 2.0, 1.0, 2.0),
                 GeometryTableUtilities.getEstimatedExtent(connection, tableLocation, "GEOM").getEnvelopeInternal());
     }
@@ -548,7 +549,7 @@ public class GeometryTableUtilsTest {
         st.execute("DROP TABLE IF EXISTS GEOMTABLE_INDEX; CREATE TABLE GEOMTABLE_INDEX (THE_GEOM GEOMETRY);");
         st.execute("INSERT INTO GEOMTABLE_INDEX VALUES ('POLYGON ((150 360, 200 360, 200 310, 150 310, 150 360))'),('POLYGON ((195.5 279, 240 279, 240 250, 195.5 250, 195.5 279))' )");
         st.execute("CREATE SPATIAL INDEX ON GEOMTABLE_INDEX(THE_GEOM)");
-        TableLocation tableLocation = TableLocation.parse("GEOMTABLE_INDEX");
+        TableLocation tableLocation = TableLocation.parse("GEOMTABLE_INDEX", DBTypes.H2GIS);
         assertEquals(new Envelope(150.0, 240.0, 250.0, 360.0),
                 GeometryTableUtilities.getEstimatedExtent(connection, tableLocation, "THE_GEOM").getEnvelopeInternal());
     }
@@ -582,12 +583,12 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testGeometryTypeNoGeomTable() throws SQLException {
-        assertNull(GeometryTableUtilities.getMetaData(connection, TableLocation.parse("NOGEOM"), "id"));
+        assertNull(GeometryTableUtilities.getMetaData(connection, TableLocation.parse("NOGEOM", DBTypes.H2), "id"));
     }
 
     @Test
     public void testGeometryTypeNotValidField() throws SQLException {
-        assertNull(GeometryTableUtilities.getMetaData(connection, TableLocation.parse("NOGEOM"), "notAField"));
+        assertNull(GeometryTableUtilities.getMetaData(connection, TableLocation.parse("NOGEOM", DBTypes.H2), "notAField"));
     }
 
     @Test
@@ -666,13 +667,14 @@ public class GeometryTableUtilsTest {
     @Test
     public void testGeometryMetadataSQL() throws Exception {
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY)");
-        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        TableLocation tableLocation = TableLocation.parse("GEO_POINT", DBTypes.H2GIS);
+        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY", geomMetadata.getSQL());
         st.execute("ALTER TABLE GEO_POINT ALTER COLUMN THE_GEOM type geometry(POINT Z, 4326)");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         st.execute("ALTER TABLE GEO_POINT ALTER COLUMN THE_GEOM type geometry(POINTZM)");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZM)", geomMetadata.getSQL());
     }
 
@@ -680,24 +682,25 @@ public class GeometryTableUtilsTest {
     public void testAlterSRID() throws Exception {
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINT))");
         st.execute("insert into geo_point VALUES('POINT(0 0)')");
-        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        TableLocation tableLocation = TableLocation.parse("GEO_POINT", DBTypes.H2GIS);
+        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals(0, geomMetadata.getSRID());
-        GeometryTableUtilities.alterSRID(connection, TableLocation.parse("GEO_POINT", DBTypes.H2), "THE_GEOM", 4326);
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        GeometryTableUtilities.alterSRID(connection, tableLocation, "THE_GEOM", 4326);
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY(POINT,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINTZ))");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals(0, geomMetadata.getSRID());
-        GeometryTableUtilities.alterSRID(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM", 4326);
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        GeometryTableUtilities.alterSRID(connection, tableLocation, "THE_GEOM", 4326);
+        geomMetadata = GeometryTableUtilities.getMetaData(connection,tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINTZ, 2154))");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals(2154, geomMetadata.getSRID());
-        GeometryTableUtilities.alterSRID(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM", 4326);
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        GeometryTableUtilities.alterSRID(connection, tableLocation, "THE_GEOM", 4326);
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, tableLocation, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
     }
@@ -706,35 +709,36 @@ public class GeometryTableUtilsTest {
     public void testUpdateSRIDFunction() throws Exception {
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINT))");
         st.execute("insert into geo_point VALUES('SRID=0;POINT(0 0)')");
-        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        TableLocation location=TableLocation.parse("GEO_POINT", DBTypes.H2);
+        GeometryMetaData geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals(0, geomMetadata.getSRID());
         st.execute("SELECT UpdateGeometrySRID('GEO_POINT','THE_GEOM',4326);");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY(POINT,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
         ResultSet res = st.executeQuery("select * from geo_point");
         res.next();
         assertEquals(4326, ((Geometry) res.getObject(1)).getSRID());
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINTZ))");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals(0, geomMetadata.getSRID());
         st.execute("SELECT UpdateGeometrySRID('GEO_POINT','THE_GEOM',4326);");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (the_geom GEOMETRY(POINTZ, 2154))");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals(2154, geomMetadata.getSRID());
         st.execute("SELECT UpdateGeometrySRID('GEO_POINT','THE_GEOM',4326);");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());
         st.execute("SELECT UpdateGeometrySRID('GEO_POINT','the_geom',4326);");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID());  
         st.execute("SELECT UpdateGeometrySRID('geo_point','the_geom',4326);");
-        geomMetadata = GeometryTableUtilities.getMetaData(connection, TableLocation.parse("GEO_POINT"), "THE_GEOM");
+        geomMetadata = GeometryTableUtilities.getMetaData(connection, location, "THE_GEOM");
         assertEquals("GEOMETRY(POINTZ,4326)", geomMetadata.getSQL());
         assertEquals(4326, geomMetadata.getSRID()); 
     }
@@ -820,13 +824,14 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testCreateDDL() throws SQLException {
+        TableLocation location = TableLocation.parse("PERSTABLE", DBTypes.H2);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable");
-        assertEquals("CREATE TABLE PERSTABLE", JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE")));
+        assertEquals("CREATE TABLE PERSTABLE", JDBCUtilities.createTableDDL(connection,location));
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY, type int, name varchar, city varchar(12), "
                 + "temperature double precision, location GEOMETRY(POINTZ, 4326), wind CHARACTER VARYING(64))");
-        String ddl = JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE"));
+        String ddl = JDBCUtilities.createTableDDL(connection, location);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute(ddl);
         assertEquals("CREATE TABLE PERSTABLE (ID INTEGER,THE_GEOM GEOMETRY,TYPE INTEGER,NAME VARCHAR,CITY VARCHAR(12),TEMPERATURE DOUBLE PRECISION,LOCATION GEOMETRY(POINTZ,4326),WIND VARCHAR(64))",
@@ -834,15 +839,15 @@ public class GeometryTableUtilsTest {
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY(POINTZ, 4326))");
         assertEquals("CREATE TABLE PERSTABLE (ID INTEGER,THE_GEOM GEOMETRY(POINTZ,4326))",
-                JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE")));
+                JDBCUtilities.createTableDDL(connection, location));
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY(POINTZ, 0))");
         assertEquals("CREATE TABLE PERSTABLE (ID INTEGER,THE_GEOM GEOMETRY(POINTZ,0))",
-                JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE")));
+                JDBCUtilities.createTableDDL(connection, location));
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY(GEOMETRY, 0))");
         assertEquals("CREATE TABLE PERSTABLE (ID INTEGER,THE_GEOM GEOMETRY)",
-                JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE")));
+                JDBCUtilities.createTableDDL(connection, location));
         assertEquals("CREATE TABLE MYTABLE (THE_GEOM GEOMETRY)",
                 JDBCUtilities.createTableDDL(st.executeQuery("SELECT the_geom from PERSTABLE"), "MYTABLE"));
     }
@@ -877,26 +882,27 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testCreateDDLSourceTarget() throws SQLException {
+        TableLocation location = TableLocation.parse("PERSTABLE", DBTypes.H2);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY, type int, name varchar, city varchar(12), "
                 + "temperature double precision, location GEOMETRY(POINTZ, 4326), wind CHARACTER VARYING(64))");
-        String ddl = JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE"), TableLocation.parse("orbisgis"));
+        String ddl = JDBCUtilities.createTableDDL(connection, location, TableLocation.parse("orbisgis",DBTypes.H2));
         assertEquals("CREATE TABLE ORBISGIS (ID INTEGER,THE_GEOM GEOMETRY,TYPE INTEGER,NAME VARCHAR,CITY VARCHAR(12),TEMPERATURE DOUBLE PRECISION,LOCATION GEOMETRY(POINTZ,4326),WIND VARCHAR(64))",
                 ddl);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, the_geom GEOMETRY, type int, name varchar, city varchar(12), "
                 + "temperature double precision, location GEOMETRY(POINTZ, 4326), wind CHARACTER VARYING(64))");
-        ddl = JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE"), TableLocation.parse("\"OrbisGIS\""));
+        ddl = JDBCUtilities.createTableDDL(connection, location, TableLocation.parse("\"OrbisGIS\"",DBTypes.H2));
         assertEquals("CREATE TABLE \"OrbisGIS\" (ID INTEGER,THE_GEOM GEOMETRY,TYPE INTEGER,NAME VARCHAR,CITY VARCHAR(12),TEMPERATURE DOUBLE PRECISION,LOCATION GEOMETRY(POINTZ,4326),WIND VARCHAR(64))",
                 ddl);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, name varchar(26))");       
-        ddl = JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE"), TableLocation.parse("\"OrbisGIS\""));
+        ddl = JDBCUtilities.createTableDDL(connection, location, TableLocation.parse("\"OrbisGIS\"",DBTypes.H2));
         assertEquals("CREATE TABLE \"OrbisGIS\" (ID INTEGER,NAME VARCHAR(26))",
                 ddl);
         st.execute("DROP TABLE IF EXISTS perstable");
         st.execute("CREATE TABLE perstable (id INTEGER PRIMARY KEY, name varchar)");       
-        ddl = JDBCUtilities.createTableDDL(connection, TableLocation.parse("PERSTABLE"), TableLocation.parse("\"OrbisGIS\""));
+        ddl = JDBCUtilities.createTableDDL(connection,location, TableLocation.parse("\"OrbisGIS\"",DBTypes.H2));
         assertEquals("CREATE TABLE \"OrbisGIS\" (ID INTEGER,NAME VARCHAR)",
                 ddl);
     }   
@@ -1230,24 +1236,26 @@ public class GeometryTableUtilsTest {
 
     @Test
     public void testIsSpatialIndexed() throws Exception {
+        TableLocation tableLocation = TableLocation.parse("GEO_POINT", DBTypes.H2GIS);
         st.execute("drop table if exists geo_point; CREATE TABLE geo_point (id int, the_geom GEOMETRY)");
         st.execute("INSERT INTO geo_point VALUES(1, 'POINT(1 2)')");
         st.execute("create spatial index geotable_sp_index on geo_point(the_geom)");
-        assertTrue(GeometryTableUtilities.isSpatialIndexed(connection, TableLocation.parse("GEO_POINT"), "the_geom"));
+        assertTrue(GeometryTableUtilities.isSpatialIndexed(connection, tableLocation, "the_geom"));
         st.execute("drop index geotable_sp_index ");
-        assertFalse(GeometryTableUtilities.isSpatialIndexed(connection, TableLocation.parse("GEO_POINT"), "the_geom"));
+        assertFalse(GeometryTableUtilities.isSpatialIndexed(connection, tableLocation, "the_geom"));
     }
 
     @Test
     @DisabledIfSystemProperty(named = "postgresql", matches = "false")
     public void testPostGISIsSpatialIndexed() throws Exception {
+        TableLocation tableLocation = TableLocation.parse("geo_point", DBTypes.POSTGIS);
         Statement stat = conPost.createStatement();
         stat.execute("drop table if exists geo_point; CREATE TABLE geo_point (id int, the_geom GEOMETRY)");
         stat.execute("INSERT INTO geo_point VALUES(1, 'POINT(1 2)')");
         stat.execute("create index geotable_sp_index on geo_point  USING GIST (the_geom);");
-        assertTrue(GeometryTableUtilities.isSpatialIndexed(conPost, TableLocation.parse("geo_point",DBTypes.POSTGIS), "the_geom"));
+        assertTrue(GeometryTableUtilities.isSpatialIndexed(conPost, tableLocation, "the_geom"));
         stat.execute("drop index geotable_sp_index ");
-        assertFalse(GeometryTableUtilities.isSpatialIndexed(conPost, TableLocation.parse("geo_point", DBTypes.POSTGIS), "the_geom"));
+        assertFalse(GeometryTableUtilities.isSpatialIndexed(conPost,tableLocation, "the_geom"));
     }
 
     @Test

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/JDBCUtilities.java
@@ -290,13 +290,12 @@ public class JDBCUtilities {
      * reference is a temporary table.
      *
      * @param connection Active connection not closed by this method
-     * @param tableReference Table reference
+     * @param tableLocation Table reference
      * @return True if the provided table is temporary.
      * @throws SQLException If the table does not exists.
      */
-    public static boolean isTemporaryTable(Connection connection, String tableReference) throws SQLException {
-        String[] location = TableLocation.split(tableReference);
-        ResultSet rs = getTablesView(connection, location[0], location[1], location[2]);
+    public static boolean isTemporaryTable(Connection connection, TableLocation tableLocation) throws SQLException {
+        ResultSet rs = getTablesView(connection, tableLocation.getCatalog(), tableLocation.getSchema(), tableLocation.getTable());
         boolean isTemporary = false;
         try {
             if (rs.next()) {
@@ -310,7 +309,7 @@ public class JDBCUtilities {
                 }
                 isTemporary = tableType.contains("TEMPORARY");
             } else {
-                throw new SQLException("The table " + tableReference + " does not exists");
+                throw new SQLException("The table " + tableLocation.toString() + " does not exists");
             }
         } finally {
             rs.close();

--- a/h2gis-utilities/src/main/java/org/h2gis/utilities/dbtypes/DBTypes.java
+++ b/h2gis-utilities/src/main/java/org/h2gis/utilities/dbtypes/DBTypes.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  * @author Sylvain Palominos (UBS Chaire GEOTERA 2021)
  */
 public enum DBTypes {
-    POSTGRESQL, POSTGIS, H2, H2GIS;
+    POSTGRESQL, POSTGIS, H2, H2GIS, UNKNOWN;
 
     /**
      * Return the list of the reserved keywords.

--- a/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
+++ b/h2gis-utilities/src/test/java/org/h2gis/utilities/JDBCUtilitiesTest.java
@@ -21,6 +21,7 @@ package org.h2gis.utilities;
 
 import org.h2gis.api.EmptyProgressVisitor;
 import org.h2gis.api.ProgressVisitor;
+import org.h2gis.utilities.dbtypes.DBTypes;
 import org.h2gis.utilities.dbtypes.DBUtils;
 import org.junit.jupiter.api.*;
 
@@ -81,8 +82,8 @@ public class JDBCUtilitiesTest {
         st.execute("DROP TABLE IF EXISTS TEMPTABLE1,perstable");
         st.execute("CREATE TEMPORARY TABLE TEMPTABLE1");
         st.execute("CREATE TABLE perstable");
-        assertTrue(JDBCUtilities.isTemporaryTable(connection, "temptable1"));
-        assertFalse(JDBCUtilities.isTemporaryTable(connection, "PERSTable"));
+        assertTrue(JDBCUtilities.isTemporaryTable(connection, TableLocation.parse("temptable1")));
+        assertFalse(JDBCUtilities.isTemporaryTable(connection, TableLocation.parse("PERSTable")));
     }
 
     @Test
@@ -92,8 +93,8 @@ public class JDBCUtilitiesTest {
         st.execute("CREATE TEMPORARY TABLE TEMPTABLE1(id int)");
         st.execute("CREATE TABLE perstable(id int)");
         st.execute("CREATE VIEW perstable_view as select * from perstable; ");
-        assertEquals(TABLE_TYPE.TEMPORARY, JDBCUtilities.getTableType(connection, TableLocation.parse("temptable1")));
-        assertEquals(TABLE_TYPE.TABLE, JDBCUtilities.getTableType(connection, TableLocation.parse("perstable")));
+        assertEquals(TABLE_TYPE.TEMPORARY, JDBCUtilities.getTableType(connection, TableLocation.parse("temptable1", DBTypes.H2)));
+        assertEquals(TABLE_TYPE.TABLE, JDBCUtilities.getTableType(connection, TableLocation.parse("perstable",DBTypes.H2)));
     }
 
     @Test

--- a/h2gis-utilities/src/test/java/org/h2gis/utilities/TableUtilitiesTest.java
+++ b/h2gis-utilities/src/test/java/org/h2gis/utilities/TableUtilitiesTest.java
@@ -95,6 +95,6 @@ public class TableUtilitiesTest {
     public void caseIdentifierTest() throws Exception {
         TableLocation tableLocation = TableLocation.parse("TATA", DBTypes.H2GIS);
         assertEquals("TATA", TableUtilities.caseIdentifier(tableLocation, "TATA", DBTypes.H2));
-        assertEquals("\"tata\"", TableUtilities.caseIdentifier(tableLocation, "TATA", DBTypes.POSTGIS));
+        assertEquals("tata", TableUtilities.caseIdentifier(tableLocation, "TATA", DBTypes.POSTGIS));
     }
 }


### PR DESCRIPTION
By default the dbtype is null
A good practice is to set the dbtype to the parser method
The ToString method has been improved to return the good catalog.schema.table pattern according the dbtype 
For performance reasons, we look for the dbtype in the TableLocation to run H2GIS-Utilities. It's better than calling each time the metabase of the database.